### PR TITLE
Fix hanging on Splash screen when mirrors are down

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/MirrorUtils.java
+++ b/src/main/java/org/spoutcraft/launcher/MirrorUtils.java
@@ -88,6 +88,8 @@ public class MirrorUtils {
 			urlConnection = new URL(url).openConnection();
 			if (url.contains("https")) {
 				HttpsURLConnection urlConnect = (HttpsURLConnection) urlConnection;
+				urlConnect.setConnectTimeout(5);
+				urlConnect.setReadTimeout(30);
 				urlConnect.setInstanceFollowRedirects(false);
 				urlConnect.setRequestMethod("HEAD");
 				int responseCode = urlConnect.getResponseCode();
@@ -96,6 +98,8 @@ public class MirrorUtils {
 				return (responseCode == HttpURLConnection.HTTP_OK);
 			} else {
 				HttpURLConnection urlConnect = (HttpURLConnection) urlConnection;
+				urlConnect.setConnectTimeout(5);
+				urlConnect.setReadTimeout(30);
 				urlConnect.setInstanceFollowRedirects(false);
 				urlConnect.setRequestMethod("HEAD");
 				int responseCode = urlConnect.getResponseCode();


### PR DESCRIPTION
The reason TechnicLauncher is hanging at the splash screen is a long timeout when checking with MirrorUtils.isAddressReachable() under certain circumstances.  I've added shorter timeouts(5 seconds to connect, 30 on reading) which brings people to the login screen much quicker.  

There's more to do, but this is a simple quick fix that ought to make people happy.
