### PR TITLE
Mojang Account Migration Support

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/MinecraftUtils.java
+++ b/src/main/java/org/spoutcraft/launcher/MinecraftUtils.java
@@ -25,6 +25,7 @@ import org.spoutcraft.launcher.exception.BadLoginException;
 import org.spoutcraft.launcher.exception.MCNetworkException;
 import org.spoutcraft.launcher.exception.MinecraftUserNotPremiumException;
 import org.spoutcraft.launcher.exception.OutdatedMCLauncherException;
+import org.spoutcraft.launcher.exception.AccountMigratedException;
 
 public class MinecraftUtils {
 
@@ -38,7 +39,7 @@ public class MinecraftUtils {
 		MinecraftUtils.options = options;
 	}
 
-	public static String[] doLogin(String user, String pass, JProgressBar progress) throws BadLoginException, MCNetworkException, OutdatedMCLauncherException, UnsupportedEncodingException, MinecraftUserNotPremiumException {
+	public static String[] doLogin(String user, String pass, JProgressBar progress) throws BadLoginException, MCNetworkException, OutdatedMCLauncherException, UnsupportedEncodingException, MinecraftUserNotPremiumException, AccountMigratedException {
 		String parameters = "user=" + URLEncoder.encode(user, "UTF-8") + "&password=" + URLEncoder.encode(pass, "UTF-8") + "&version=" + 13;
 		String result = PlatformUtils.excutePost("https://login.minecraft.net/", parameters, progress);
 		if (result == null) { throw new MCNetworkException(); }
@@ -49,7 +50,9 @@ public class MinecraftUtils {
 				throw new MinecraftUserNotPremiumException();
 			} else if (result.trim().equals("Old version")) {
 				throw new OutdatedMCLauncherException();
-			} else {
+			} else if (result.trim().equals("Account migrated, use e-mail as username.")) {
+				throw new AccountMigratedException();
+		    }else {
 				System.err.print("Unknown login result: " + result);
 			}
 			throw new MCNetworkException();

--- a/src/main/java/org/spoutcraft/launcher/exception/AccountMigratedException.java
+++ b/src/main/java/org/spoutcraft/launcher/exception/AccountMigratedException.java
@@ -1,0 +1,32 @@
+package org.spoutcraft.launcher.exception;
+
+import java.io.IOException;
+
+public class AccountMigratedException extends IOException {
+	private static final long	serialVersionUID	= 1L;
+	private final Throwable		cause;
+	private final String			message;
+
+	public AccountMigratedException(String message) {
+		this(null, message);
+	}
+
+	public AccountMigratedException(Throwable throwable, String message) {
+		this.cause = throwable;
+		this.message = message;
+	}
+
+	public AccountMigratedException() {
+		this(null, "Account migrated, use e-mail as username.");
+	}
+
+	@Override
+	public Throwable getCause() {
+		return this.cause;
+	}
+
+	@Override
+	public String getMessage() {
+		return this.message;
+	}
+}

--- a/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
@@ -80,6 +80,7 @@ import org.spoutcraft.launcher.SettingsUtil;
 import org.spoutcraft.launcher.SpoutFocusTraversalPolicy;
 import org.spoutcraft.launcher.Util;
 import org.spoutcraft.launcher.async.DownloadListener;
+import org.spoutcraft.launcher.exception.AccountMigratedException;
 import org.spoutcraft.launcher.exception.BadLoginException;
 import org.spoutcraft.launcher.exception.MCNetworkException;
 import org.spoutcraft.launcher.exception.MinecraftUserNotPremiumException;
@@ -663,6 +664,10 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 				try {
 					values = MinecraftUtils.doLogin(user, pass, progressBar);
 					return true;
+				} catch (AccountMigratedException e) {
+					JOptionPane.showMessageDialog(getParent(), "Account migrated, use e-mail as username");
+					this.cancel(true);
+					progressBar.setVisible(false);
 				} catch (BadLoginException e) {
 					JOptionPane.showMessageDialog(getParent(), "Incorrect usernameField/passwordField combination");
 					this.cancel(true);
@@ -740,7 +745,7 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 				} catch (NoSuchAlgorithmException e) {
 				}
 
-				gameUpdater.user = values[2].trim();
+				gameUpdater.user = usernameField.getSelectedItem().toString(); //values[2].trim();
 				gameUpdater.downloadTicket = values[1].trim();
 				if (!cmdLine) {
 					String password = new String(passwordField.getPassword());


### PR DESCRIPTION
Users that have migrated their Minecraft account to Mojang accounts now
have to enter their email, not just the username.

Support new error message for migrated accounts, and allow users to
save the entered username
