### PR TITLE
Make Launcher able to compile against the 1.6JDK

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/Util.java
+++ b/src/main/java/org/spoutcraft/launcher/Util.java
@@ -42,23 +42,23 @@ public class Util {
 		combobox.addItem(new ComboItem(label, value));
 	}
 
-	public static void setSelectedComboByLabel(JComboBox<ComboItem> combobox, String label) {
+	public static void setSelectedComboByLabel(JComboBox combobox, String label) {
 		for (int i = 0; i < combobox.getItemCount(); i++) {
-			if ((combobox.getItemAt(i)).getLabel().equalsIgnoreCase(label)) {
+			if (((ComboItem)combobox.getItemAt(i)).getLabel().equalsIgnoreCase(label)) {
 				combobox.setSelectedIndex(i);
 			}
 		}
 	}
 
-	public static void setSelectedComboByValue(JComboBox<ComboItem> combobox, String value) {
+	public static void setSelectedComboByValue(JComboBox combobox, String value) {
 		for (int i = 0; i < combobox.getItemCount(); i++) {
-			if ((combobox.getItemAt(i)).getValue().equalsIgnoreCase(value)) {
+			if (((ComboItem)combobox.getItemAt(i)).getValue().equalsIgnoreCase(value)) {
 				combobox.setSelectedIndex(i);
 			}
 		}
 	}
 
-	public static String getSelectedValue(JComboBox<ComboItem> combobox) {
+	public static String getSelectedValue(JComboBox combobox) {
 		return ((ComboItem) combobox.getSelectedItem()).getValue();
 	}
 

--- a/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/LoginForm.java
@@ -127,7 +127,7 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 	Container																	loginPane					= new Container();
 	Container																	offlinePane				= new Container();
 	// private final JLabel lblLogo;
-	private final JComboBox<String>						modpackList;
+	private final JComboBox						modpackList;
 
 	public LoginForm() {
 		loadLauncherData();
@@ -177,7 +177,7 @@ public class LoginForm extends JFrame implements ActionListener, DownloadListene
 			}
 		}
 		String[] itemArray = new String[i];
-		modpackList = new JComboBox<String>(items.toArray(itemArray));
+		modpackList = new JComboBox(items.toArray(itemArray));
 		modpackList.setBounds(10, 10, 328, 100);
 		ComboBoxRenderer renderer = new ComboBoxRenderer();
 		renderer.setPreferredSize(new Dimension(200, 110));

--- a/src/main/java/org/spoutcraft/launcher/gui/widget/CheckBoxNodeTreeSample.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/widget/CheckBoxNodeTreeSample.java
@@ -143,7 +143,7 @@ public class CheckBoxNodeTreeSample {
 
 		File workingDirectory = PlatformUtils.getWorkingDirectory();
 		Image im = Toolkit.getDefaultToolkit().getImage(new File(workingDirectory, "splash_logo.png").getAbsolutePath());
-		JList<Image> list = new JList<Image>(new Image[] { im, im });
+		JList list = new JList(new Image[] { im, im });
 
 		list.setLayoutOrientation(JList.HORIZONTAL_WRAP);
 		Image tek = Toolkit.getDefaultToolkit().getImage(new File(workingDirectory, "tekkit_unselected.png").getAbsolutePath());


### PR DESCRIPTION
Remove 1.7 dependancies from Launcher to allow compiling against Java 1.6

Done to fix errors that prevent JDK 1.7 on OS X from transitioning between the launcher and the applet for the client.
