### PR TITLE
Log more errors

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/Launcher.java
+++ b/src/main/java/org/spoutcraft/launcher/Launcher.java
@@ -105,7 +105,7 @@ public class Launcher {
 			throw new MinecraftVerifyException(ex);
 		} catch (Throwable t) {
 			throw new UnknownMinecraftException(t);
-		}
+		} 
 	}
 
 	/*

--- a/src/main/java/org/spoutcraft/launcher/exception/CorruptedMinecraftJarException.java
+++ b/src/main/java/org/spoutcraft/launcher/exception/CorruptedMinecraftJarException.java
@@ -1,15 +1,9 @@
 package org.spoutcraft.launcher.exception;
 
 public class CorruptedMinecraftJarException extends RuntimeException {
-	private final Throwable	cause;
 
 	public CorruptedMinecraftJarException(Throwable ex) {
-		cause = ex;
-	}
-
-	@Override
-	public Throwable getCause() {
-		return this.cause;
+		super(ex);
 	}
 
 	private static final long	serialVersionUID	= 5550898219922574735L;

--- a/src/main/java/org/spoutcraft/launcher/exception/MinecraftVerifyException.java
+++ b/src/main/java/org/spoutcraft/launcher/exception/MinecraftVerifyException.java
@@ -2,30 +2,17 @@ package org.spoutcraft.launcher.exception;
 
 public class MinecraftVerifyException extends Exception {
 	private static final long	serialVersionUID	= 1L;
-	private final Throwable		cause;
-	private final String			message;
 
 	public MinecraftVerifyException(String message) {
-		this(null, message);
+		super(message);
 	}
 
 	public MinecraftVerifyException(Throwable throwable, String message) {
-		this.cause = throwable;
-		this.message = message;
+		super(message, throwable);
 	}
 
 	public MinecraftVerifyException(Throwable throwable) {
-		this.cause = throwable;
-		this.message = null;
+		super(throwable);
 	}
 
-	@Override
-	public Throwable getCause() {
-		return this.cause;
-	}
-
-	@Override
-	public String getMessage() {
-		return this.message;
-	}
 }

--- a/src/main/java/org/spoutcraft/launcher/exception/UnknownMinecraftException.java
+++ b/src/main/java/org/spoutcraft/launcher/exception/UnknownMinecraftException.java
@@ -4,6 +4,7 @@ public class UnknownMinecraftException extends RuntimeException {
 	private final Throwable	cause;
 
 	public UnknownMinecraftException(Throwable ex) {
+		super(ex);
 		cause = ex;
 	}
 

--- a/src/main/java/org/spoutcraft/launcher/gui/LauncherFrame.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/LauncherFrame.java
@@ -72,14 +72,20 @@ public class LauncherFrame extends Frame implements WindowListener {
 		} catch (CorruptedMinecraftJarException corruption) {
 			corruption.printStackTrace();
 		} catch (MinecraftVerifyException verify) {
+			System.err.println("Exception thrown while initializing MineCraft.");
+			verify.printStackTrace();
 			OptionDialog.clearCache();
 			JOptionPane.showMessageDialog(getParent(), "The minecraft installation was corrupted. \nThe minecraft installation has been cleaned. \nTry to login again. If that fails, close and \nrestart the appplication.");
 			this.setVisible(false);
 			this.dispose();
 			return ERROR_IN_LAUNCH;
+		} catch (Throwable t) {
+			System.err.println("Exception thrown while initializing MineCraft.");
+			t.printStackTrace();
+			applet = null;
 		}
 		if (applet == null) {
-			String message = "Failed to launch Launcher!";
+			String message = "Failed to start launcher, errors reported in the log.";
 			this.setVisible(false);
 			JOptionPane.showMessageDialog(getParent(), message);
 			this.dispose();
@@ -111,10 +117,18 @@ public class LauncherFrame extends Frame implements WindowListener {
 		this.add(minecraft);
 		validate();
 
-		minecraft.init();
-		minecraft.setSize(getWidth(), getHeight());
-
-		minecraft.start();
+		try {
+			minecraft.init();
+			minecraft.setSize(getWidth(), getHeight());
+			minecraft.start();
+		} catch (Throwable t) {
+			System.err.println("Exception thrown while initializing MineCraft.");
+			t.printStackTrace();
+			JOptionPane.showMessageDialog(getParent(), "Minecraft failed to start, errors reported in the log.");
+			this.setVisible(false);
+			this.dispose();
+			return ERROR_IN_LAUNCH;
+		}
 
 		this.setVisible(true);
 		return SUCCESSFUL_LAUNCH;


### PR DESCRIPTION
Thought you might be interested in the following fixes. Along with the additional logging, I think this fixes the blank screen at launch.
- minecraft exceptions now log the causes to exceptions properly
- All throwables are caught in loading and launching the MineCraftApplet
