### PR TITLE
Native Mac OS X Fullscreen Support

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/gui/LauncherFrame.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/LauncherFrame.java
@@ -48,17 +48,18 @@ public class LauncherFrame extends JFrame implements WindowListener {
 
 	public LauncherFrame() {
 		super(ModPackListYML.currentModPackLabel);
-	    try
-	    {
-	    	Class<?> fullScreenUtilityClass = Class.forName("com.apple.eawt.FullScreenUtilities");
-	    	java.lang.reflect.Method setWindowCanFullScreenMethod = fullScreenUtilityClass.getDeclaredMethod("setWindowCanFullScreen", new Class[] { Window.class, Boolean.TYPE });
-	    	setWindowCanFullScreenMethod.invoke(null, new Object[] { this, Boolean.valueOf(true) });
-	    } catch (ClassNotFoundException e) {
-	    	// No big loss, probably on a non-Mac platform.
-	    	System.out.println("Couldn't fullscreenify");
-	    } catch (Exception e) {
-	    	e.printStackTrace();
-	    }
+		if (System.getProperty("os.name").contains("OS X")) {
+			try
+			{
+				Class<?> fullScreenUtilityClass = Class.forName("com.apple.eawt.FullScreenUtilities");
+				java.lang.reflect.Method setWindowCanFullScreenMethod = fullScreenUtilityClass.getDeclaredMethod("setWindowCanFullScreen", new Class[] { Window.class, Boolean.TYPE });
+				setWindowCanFullScreenMethod.invoke(null, new Object[] { this, Boolean.valueOf(true) });
+			} catch (Exception e) {
+				// This is not a fatal exception, so just log it for brevity.
+				e.printStackTrace();
+			}
+		}
+
 		super.setVisible(true);
 		Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
 		this.setLocation((dim.width - 870) / 2, (dim.height - 518) / 2);

--- a/src/main/java/org/spoutcraft/launcher/gui/LauncherFrame.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/LauncherFrame.java
@@ -19,11 +19,12 @@ package org.spoutcraft.launcher.gui;
 
 import java.applet.Applet;
 import java.awt.Dimension;
-import java.awt.Frame;
 import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 
+import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 
 import org.spoutcraft.launcher.Launcher;
@@ -36,7 +37,7 @@ import org.spoutcraft.launcher.exception.MinecraftVerifyException;
 import org.spoutcraft.launcher.modpacks.ModPackListYML;
 import org.spoutcraft.launcher.modpacks.ModPackYML;
 
-public class LauncherFrame extends Frame implements WindowListener {
+public class LauncherFrame extends JFrame implements WindowListener {
 	private static final long				serialVersionUID	= 4524937541564722358L;
 	private MinecraftAppletEnglober	minecraft;
 	private LoginForm								loginForm					= null;
@@ -47,6 +48,17 @@ public class LauncherFrame extends Frame implements WindowListener {
 
 	public LauncherFrame() {
 		super(ModPackListYML.currentModPackLabel);
+	    try
+	    {
+	    	Class<?> fullScreenUtilityClass = Class.forName("com.apple.eawt.FullScreenUtilities");
+	    	java.lang.reflect.Method setWindowCanFullScreenMethod = fullScreenUtilityClass.getDeclaredMethod("setWindowCanFullScreen", new Class[] { Window.class, Boolean.TYPE });
+	    	setWindowCanFullScreenMethod.invoke(null, new Object[] { this, Boolean.valueOf(true) });
+	    } catch (ClassNotFoundException e) {
+	    	// No big loss, probably on a non-Mac platform.
+	    	System.out.println("Couldn't fullscreenify");
+	    } catch (Exception e) {
+	    	e.printStackTrace();
+	    }
 		super.setVisible(true);
 		Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
 		this.setLocation((dim.width - 870) / 2, (dim.height - 518) / 2);
@@ -110,7 +122,7 @@ public class LauncherFrame extends Frame implements WindowListener {
 
 		this.add(minecraft);
 		validate();
-
+		
 		minecraft.init();
 		minecraft.setSize(getWidth(), getHeight());
 


### PR DESCRIPTION
## Description

I've added some code to add the little full screen button that appears in the top-right on Macs.  This gives you the ability to run Minecraft as a fullscreen window in its own space, which is very desirable functionality for games on OS X!  I've added this to the Technic Pack launcher for the following reasons:
- It can't be a Minecraft Mod because the frame Minecraft runs in is actually spawned by the launcher.  Making it a Minecraft Mod means creating a frame from within the applet, which results in two Windows being created, one which is empty (spawned by the launcher) and the one spawned by the mod.  This is fairly inelegant.
- I could've added it to the Spoutcraft-Launcher directly (and I very well still may), but I figured majority of Tekkit users are running it through this launcher and I'd like to expedite the ability for Mac users to get this functionality by pushing straight into the launcher they use.
## Screenshots

Minecraft Window with Fullscreen Button:
![Minecraft Window](http://cl.ly/image/0b1Q1C470e3x/Screen%20Shot%202012-08-07%20at%2011.44.00%20PM.png)
How it appears in OS X's Mission Control:
![Mission Control](http://cl.ly/image/2Y430Q1q1d2A/ExposePreview.jpg)

Signed-off-by: Tyrone Trevorrow tyrone@sudeium.com
