### PR TITLE
Set Loading Screen to be not always on top.

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/gui/LoadingScreen.java
+++ b/src/main/java/org/spoutcraft/launcher/gui/LoadingScreen.java
@@ -97,7 +97,7 @@ public class LoadingScreen extends JDialog {
 		setLocation(screenSize.width / 2 - (getWidth() / 2), screenSize.height / 2 - (getHeight() / 2));
 
 		// keep window on top of others
-		setAlwaysOnTop(true);
+		setAlwaysOnTop(false);
 	}
 
 	public void close() {


### PR DESCRIPTION
Some people (especially those with a slow internet connection) find it
annoying to have this loading screen in their way when doing something
else while the launcher loads.
