### PR TITLE
Fix for non transparent Forums/Donate icons on OSX

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/skin/MetroLoginFrame.java
+++ b/src/main/java/org/spoutcraft/launcher/skin/MetroLoginFrame.java
@@ -208,12 +208,14 @@ public class MetroLoginFrame extends LoginFrame implements ActionListener, KeyLi
 		JButton forums = new ImageHyperlinkButton("http://forums.technicpack.net/");
 		forums.setToolTipText("Visit the forums");
 		forums.setBounds(10, loginStrip.getY() + 7, 90, 90);
+		forums.setBorderPainted(false);
 		setIcon(forums, "forums.png", forums.getWidth(), forums.getHeight());
 		
 		// Donate link
 		JButton donate = new ImageHyperlinkButton("http://www.technicpack.net/donate/");
 		donate.setToolTipText("Donate to the modders");
 		donate.setBounds(forums.getX() + 100,  forums.getY(), 90, 90);
+		donate.setBorderPainted(false);
 		setIcon(donate, "donate.png", forums.getWidth(), forums.getHeight());
 
 		// Issues link


### PR DESCRIPTION
On OSX 10.8.3 it looks like this:
![](http://puu.sh/21MY1.png)
