### PR TITLE
Lock login button just before doLogin()

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/skin/MetroLoginFrame.java
+++ b/src/main/java/org/spoutcraft/launcher/skin/MetroLoginFrame.java
@@ -478,9 +478,9 @@ public class MetroLoginFrame extends LoginFrame implements ActionListener, KeyLi
 			if (pack instanceof AddPack) {
 				return;
 			}
-			lockLoginButton(false);
 			String pass = new String(this.pass.getPassword());
 			if (getSelectedUser().length() > 0 && pass.length() > 0) {
+				lockLoginButton(false);
 				this.doLogin(getSelectedUser(), pass);
 				if (remember.isSelected()) {
 					saveUsername(getSelectedUser(), pass);


### PR DESCRIPTION
Don't lock it if username and/or password is empty
