### PR TITLE
Fix mojang account startup autocomplete

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/skin/MetroLoginFrame.java
+++ b/src/main/java/org/spoutcraft/launcher/skin/MetroLoginFrame.java
@@ -373,7 +373,7 @@ public class MetroLoginFrame extends LoginFrame implements ActionListener, KeyLi
 
 	public void setUser(String name) {
 		if (name != null) {
-			DynamicButton user = userButtons.get(name);
+			DynamicButton user = userButtons.get(this.getUsername(name));
 			if (user != null) {
 				user.doClick();
 			}


### PR DESCRIPTION
Mojang accounts (emails) are not pre-filled into login box after start.
