### PR TITLE
Fix Spout repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
 	<!-- Project dependencies -->
 	<dependencies>
 		<!-- Included in final JAR -->
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.0</version>
+        </dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 	<repositories>
 		<repository>
 			<id>spout-repo</id>
-			<url>http://repo.spout.org</url>
+			<url>http://nexus.spout.org/content/groups/public/</url>
 			<snapshots>
 				<enabled>true</enabled>
 				<updatePolicy>always</updatePolicy>
@@ -68,7 +68,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spout-repo</id>
-			<url>http://repo.spout.org</url>
+			<url>http://nexus.spout.org/content/groups/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
 


### PR DESCRIPTION
Make it possible to build on a clean setup. repo.spout.org causes dependency issues on a clean setup.
