### PR TITLE
Avatar Head fix

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/skin/LauncherFrame.java
+++ b/src/main/java/org/spoutcraft/launcher/skin/LauncherFrame.java
@@ -438,9 +438,10 @@ public class LauncherFrame extends JFrame implements ActionListener, KeyListener
 
 	public void updateFaces() {
 		for (String user : userButtons.keySet()) {
-			BufferedImage image = getUserImage(user);
-			if (image != null) {
-				userButtons.get(user).updateIcon(image);
+                    String userDisplayName = Launcher.getUsers().getUser(user).getDisplayName();
+                    BufferedImage image = getUserImage(userDisplayName);
+                    if (image != null) {
+			userButtons.get(user).updateIcon(image);
 			}
 		}
 	}


### PR DESCRIPTION
Mojang accounts were not supported by the current system.
This workaround uses the display name (e.g. Spyboticsguy vs an email)
when accessing the api, allowing the image api to retrieve the avatar's
face.
