### PR TITLE
Add optional launcher hide/close on pack launch

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/InstallThread.java
+++ b/src/main/java/org/spoutcraft/launcher/InstallThread.java
@@ -35,6 +35,7 @@ import javax.swing.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.zip.ZipException;
+import net.technicpack.launchercore.util.LaunchAction;
 
 public class InstallThread extends Thread {
 	private final User user;
@@ -80,13 +81,13 @@ public class InstallThread extends Thread {
 			e.printStackTrace();
 		} finally {
 			Launcher.getFrame().getProgressBar().setVisible(false);
-			int launchAction = Settings.getLaunchAction();
+			LaunchAction launchAction = Settings.getLaunchAction();
 			switch (launchAction) {
-				case 1: Launcher.getFrame().setVisible(false);
+				case HIDE: Launcher.getFrame().setVisible(false);
 					break;
-				case 2: System.exit(0);
+				case CLOSE: System.exit(0);
 					break;
-				case 3: break; //do nothing
+				case NOTHING: break; //do nothing
 			}
 
 			finished = true;

--- a/src/main/java/org/spoutcraft/launcher/InstallThread.java
+++ b/src/main/java/org/spoutcraft/launcher/InstallThread.java
@@ -66,7 +66,8 @@ public class InstallThread extends Thread {
 
 			StartupParameters params = SpoutcraftLauncher.params;
 			LaunchOptions options = new LaunchOptions( pack.getDisplayName(), pack.getIconPath(), params.getWidth(), params.getHeight(), params.getFullscreen());
-			minecraftLauncher.launch(user, options);
+			LauncherUnhider unhider = new LauncherUnhider();
+			minecraftLauncher.launch(user, options, unhider);
 		} catch (PackNotAvailableOfflineException e) {
 			JOptionPane.showMessageDialog(Launcher.getFrame(), e.getMessage(), "Cannot Start Modpack", JOptionPane.WARNING_MESSAGE);
 		} catch (DownloadException e) {
@@ -79,6 +80,15 @@ public class InstallThread extends Thread {
 			e.printStackTrace();
 		} finally {
 			Launcher.getFrame().getProgressBar().setVisible(false);
+			int launchAction = Settings.getLaunchAction();
+			switch (launchAction) {
+				case 1: Launcher.getFrame().setVisible(false);
+					break;
+				case 2: System.exit(0);
+					break;
+				case 3: break; //do nothing
+			}
+
 			finished = true;
 		}
 	}

--- a/src/main/java/org/spoutcraft/launcher/LauncherUnhider.java
+++ b/src/main/java/org/spoutcraft/launcher/LauncherUnhider.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.spoutcraft.launcher;
+
+import net.technicpack.launchercore.launch.MinecraftExitListener;
+import net.technicpack.launchercore.launch.MinecraftProcess;
+import net.technicpack.launchercore.util.Settings;
+
+public class LauncherUnhider implements MinecraftExitListener {
+	@Override
+	public void onMinecraftExit(MinecraftProcess process) {
+		if (Settings.getLaunchAction() == 1) Launcher.getFrame().setVisible(true);
+	}
+}

--- a/src/main/java/org/spoutcraft/launcher/LauncherUnhider.java
+++ b/src/main/java/org/spoutcraft/launcher/LauncherUnhider.java
@@ -21,11 +21,12 @@ package org.spoutcraft.launcher;
 
 import net.technicpack.launchercore.launch.MinecraftExitListener;
 import net.technicpack.launchercore.launch.MinecraftProcess;
+import net.technicpack.launchercore.util.LaunchAction;
 import net.technicpack.launchercore.util.Settings;
 
 public class LauncherUnhider implements MinecraftExitListener {
 	@Override
 	public void onMinecraftExit(MinecraftProcess process) {
-		if (Settings.getLaunchAction() == 1) Launcher.getFrame().setVisible(true);
+		if (Settings.getLaunchAction() == LaunchAction.HIDE) Launcher.getFrame().setVisible(true);
 	}
 }

--- a/src/main/java/org/spoutcraft/launcher/skin/options/LauncherOptions.java
+++ b/src/main/java/org/spoutcraft/launcher/skin/options/LauncherOptions.java
@@ -55,6 +55,7 @@ import java.awt.event.MouseMotionListener;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
+import net.technicpack.launchercore.util.LaunchAction;
 
 public class LauncherOptions extends JDialog implements ActionListener, MouseListener, MouseMotionListener {
 	private static final long serialVersionUID = 1L;
@@ -327,7 +328,7 @@ public class LauncherOptions extends JDialog implements ActionListener, MouseLis
 			int mem = Memory.memoryOptions[memory.getSelectedIndex()].getSettingsId();
 			Settings.setMemory(mem);
 			Settings.setBuildStream(buildStream);
-			Settings.setLaunchAction(onLaunch.getSelectedIndex() + 1);
+			Settings.setLaunchAction((LaunchAction)onLaunch.getSelectedItem());
 			if (directoryChanged) {
 				Settings.setMigrate(true);
 				Settings.setMigrateDir(installedDirectory);
@@ -401,15 +402,15 @@ public class LauncherOptions extends JDialog implements ActionListener, MouseLis
 	}
 
 	private void populateOnLaunch(JComboBox onLaunch) {
-		onLaunch.addItem("Hide Launcher");
-		onLaunch.addItem("Close Launcher and Console");
-		onLaunch.addItem("Stay Open");
-		int selectedAction = Settings.getLaunchAction();
-		if (selectedAction == 0) {
-			onLaunch.setSelectedIndex(0);
-			Settings.setLaunchAction(1);
+		onLaunch.addItem(LaunchAction.HIDE);
+		onLaunch.addItem(LaunchAction.CLOSE);
+		onLaunch.addItem(LaunchAction.NOTHING);
+		LaunchAction selectedAction = Settings.getLaunchAction();
+		if (selectedAction == null) {
+			onLaunch.setSelectedItem(LaunchAction.HIDE);
+			Settings.setLaunchAction(LaunchAction.HIDE);
 		} else {
-			onLaunch.setSelectedIndex(Settings.getLaunchAction()- 1);
+			onLaunch.setSelectedItem(Settings.getLaunchAction());
 		}
 	}
 

--- a/src/main/java/org/spoutcraft/launcher/skin/options/LauncherOptions.java
+++ b/src/main/java/org/spoutcraft/launcher/skin/options/LauncherOptions.java
@@ -73,6 +73,7 @@ public class LauncherOptions extends JDialog implements ActionListener, MouseLis
 	private JLabel build;
 	private LiteButton logs;
 	private JComboBox memory;
+	private JComboBox onLaunch;
 	private JRadioButton beta;
 	private JRadioButton stable;
 	private JFileChooser fileChooser;
@@ -174,11 +175,20 @@ public class LauncherOptions extends JDialog implements ActionListener, MouseLis
 		memory.setBounds(memoryLabel.getX() + memoryLabel.getWidth() + 10, memoryLabel.getY(), 100, 20);
 		populateMemory(memory);
 
+		JLabel onLaunchLabel = new JLabel("On Pack Launch: ");
+		onLaunchLabel.setFont(minecraft);
+		onLaunchLabel.setBounds(10, memoryLabel.getY() + memoryLabel.getHeight() + 10, 125, 20);
+		onLaunchLabel.setForeground(Color.WHITE);
+		onLaunchLabel.setHorizontalAlignment(SwingConstants.CENTER);
+
+		onLaunch = new JComboBox();
+		onLaunch.setBounds(onLaunchLabel.getX() + onLaunchLabel.getWidth() + 10, onLaunchLabel.getY(), 145, 20);
+		populateOnLaunch(onLaunch);
 
 		installedDirectory = Settings.getDirectory();
 
 		packLocation = new LiteTextBox(this, "");
-		packLocation.setBounds(10, memoryLabel.getY() + memoryLabel.getHeight() + 10, FRAME_WIDTH - 20, 25);
+		packLocation.setBounds(10, onLaunchLabel.getY() + onLaunchLabel.getHeight() + 10, FRAME_WIDTH - 20, 25);
 		packLocation.setFont(minecraft.deriveFont(10F));
 		packLocation.setText(installedDirectory);
 		packLocation.setEnabled(false);
@@ -226,6 +236,8 @@ public class LauncherOptions extends JDialog implements ActionListener, MouseLis
 		contentPane.add(title);
 		contentPane.add(memory);
 		contentPane.add(memoryLabel);
+		contentPane.add(onLaunch);
+		contentPane.add(onLaunchLabel);
 		contentPane.add(save);
 		contentPane.add(background);
 
@@ -315,6 +327,7 @@ public class LauncherOptions extends JDialog implements ActionListener, MouseLis
 			int mem = Memory.memoryOptions[memory.getSelectedIndex()].getSettingsId();
 			Settings.setMemory(mem);
 			Settings.setBuildStream(buildStream);
+			Settings.setLaunchAction(onLaunch.getSelectedIndex() + 1);
 			if (directoryChanged) {
 				Settings.setMigrate(true);
 				Settings.setMigrateDir(installedDirectory);
@@ -387,5 +400,17 @@ public class LauncherOptions extends JDialog implements ActionListener, MouseLis
 		return build;
 	}
 
+	private void populateOnLaunch(JComboBox onLaunch) {
+		onLaunch.addItem("Hide Launcher");
+		onLaunch.addItem("Close Launcher and Console");
+		onLaunch.addItem("Stay Open");
+		int selectedAction = Settings.getLaunchAction();
+		if (selectedAction == 0) {
+			onLaunch.setSelectedIndex(0);
+			Settings.setLaunchAction(1);
+		} else {
+			onLaunch.setSelectedIndex(Settings.getLaunchAction()- 1);
+		}
+	}
 
 }


### PR DESCRIPTION
This commit, coupled with its twin in the LauncherCore repo, adds
functionality for the user to select what their launcher does upon
launching the game. It can close, hide itself until the game is closed,
or do nothing and remain open in the background.

Signed-off-by: Tristen Allen spyboticsguy@gmail.com
