### PR TITLE
Added commands to garbage collect PermGenSpace

### DIFF
--- a/src/main/java/org/spoutcraft/launcher/entrypoint/Mover.java
+++ b/src/main/java/org/spoutcraft/launcher/entrypoint/Mover.java
@@ -80,6 +80,9 @@ public class Mover {
 				commands.add("java");
 			}
 			commands.add("-Xmx256m");
+			commands.add("-XX:+UseConcMarkSweepGC");
+			commands.add("-XX:+CMSPermGenSweepingEnabled");
+			commands.add("-XX:+CMSClassUnloadingEnabled");
 			commands.add("-cp");
 			commands.add(codeSource.getAbsolutePath());
 			commands.add(SpoutcraftLauncher.class.getName());

--- a/src/main/java/org/spoutcraft/launcher/entrypoint/Start.java
+++ b/src/main/java/org/spoutcraft/launcher/entrypoint/Start.java
@@ -120,6 +120,9 @@ public class Start {
 					commands.add("java");
 				}
 				commands.add("-Xmx256m");
+				commands.add("-XX:+UseConcMarkSweepGC");
+				commands.add("-XX:+CMSPermGenSweepingEnabled");
+				commands.add("-XX:+CMSClassUnloadingEnabled");
 				commands.add("-cp");
 				commands.add(temp.getAbsolutePath());
 				commands.add(Mover.class.getName());


### PR DESCRIPTION
While creating a ModPack, I ran out of PermGen space. There used to be an "Increase PermGen Space" checkbox, but it is no longer there. I added the JVM arguments to Garbage Collect the PermGen space along with the normal memory. This way, no one should run out of PermGen space because it is garbage collected.

I have not tested this on other operating systems besides Mac. Without these arguments the ModPack did not launch; and with them, it did.
