### PR TITLE
maven-shade-plugin version upgraded from v2.0 to v2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.0</version>
+				<version>2.2</version>
 				<executions>
 					<execution>
 						<configuration>


### PR DESCRIPTION
Hi, this PR upgrades the maven-shade-plugin version you use from v2.0 to v2.2, in order to solve this problem I ran into:

```
$ mvn -version
Apache Maven 3.2.1 (ea8b2b07643dbb1b84b6d16e1f08391b666bc1e9; 2014-02-14T18:37:52+01:00)
Maven home: /home/vorburger/bin/maven-3.2.1
Java version: 1.7.0_51, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-7-openjdk-amd64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "3.2.0-60-generic", arch: "amd64", family: "unix"

$ mvn package
(...)
[INFO] --- maven-shade-plugin:2.0:shade (default) @ launcher ---
[INFO] Including net.technicpack:launchercore:jar:1.0.0-SNAPSHOT in the shaded jar.
[INFO] Including com.google.code.gson:gson:jar:2.2.4 in the shaded jar.
[INFO] Including commons-codec:commons-codec:jar:1.8 in the shaded jar.
[INFO] Including commons-io:commons-io:jar:2.4 in the shaded jar.
[INFO] Including org.apache.commons:commons-lang3:jar:3.1 in the shaded jar.
[INFO] Including com.beust:jcommander:jar:1.30 in the shaded jar.
[INFO] Including org.yaml:snakeyaml:jar:1.11 in the shaded jar.
[INFO] Including org.swinglabs:swing-layout:jar:1.0.3 in the shaded jar.
[INFO] Including org.swinglabs:swing-worker:jar:1.1 in the shaded jar.
[INFO] No artifact matching filter org.jdom:jdom
[INFO] No artifact matching filter rome:rome
[INFO] Minimizing jar org.spoutcraft:launcher:jar:3.0-0
[INFO] Minimized 1226 -> 939 (76%)
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing /home/vorburger/dev/withDev/ModPack/TechnicLauncher/target/launcher-3.0-0.jar with /home/vorburger/dev/withDev/ModPack/TechnicLauncher/target/launcher-3.0-0-shaded.jar
[INFO] Dependency-reduced POM written at: /home/vorburger/dev/withDev/ModPack/TechnicLauncher/dependency-reduced-pom.xml
[WARNING] Error injecting: org.apache.maven.shared.dependency.graph.internal.Maven3DependencyGraphBuilder
java.lang.NoClassDefFoundError: org/sonatype/aether/graph/Dependency
    at java.lang.Class.getDeclaredMethods0(Native Method)
    at java.lang.Class.privateGetDeclaredMethods(Class.java:2531)
    at java.lang.Class.getDeclaredMethods(Class.java:1855)
    at com.google.inject.spi.InjectionPoint.getInjectionPoints(InjectionPoint.java:674)
    at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields(InjectionPoint.java:366)
    at com.google.inject.internal.ConstructorBindingImpl.getInternalDependencies(ConstructorBindingImpl.java:165)
    at com.google.inject.internal.InjectorImpl.getInternalDependencies(InjectorImpl.java:609)
    at com.google.inject.internal.InjectorImpl.cleanup(InjectorImpl.java:565)
    at com.google.inject.internal.InjectorImpl.initializeJitBinding(InjectorImpl.java:551)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:865)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:790)
    at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:278)
    at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:210)
    at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:986)
    at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1019)
    at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:982)
    at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
    at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
    at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
    at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
    at org.eclipse.sisu.plexus.PlexusLifecycleManager.onProvision(PlexusLifecycleManager.java:133)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
    at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
    at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
    at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
    at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
    at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
    at com.google.inject.Scopes$1$1.get(Scopes.java:59)
    at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
    at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
    at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1047)
    at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
    at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
    at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
    at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:260)
    at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:240)
    at org.apache.maven.shared.dependency.graph.internal.DefaultDependencyGraphBuilder.buildDependencyGraph(DefaultDependencyGraphBuilder.java:60)
    at org.apache.maven.plugins.shade.mojo.ShadeMojo.updateExcludesInDeps(ShadeMojo.java:965)
    at org.apache.maven.plugins.shade.mojo.ShadeMojo.createDependencyReducedPom(ShadeMojo.java:938)
    at org.apache.maven.plugins.shade.mojo.ShadeMojo.execute(ShadeMojo.java:544)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:133)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:108)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:76)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:116)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:361)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:213)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:157)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.ClassNotFoundException: org.sonatype.aether.graph.Dependency
    at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:259)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:235)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:227)
    ... 64 more
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 7.980 s
[INFO] Finished at: 2014-04-19T11:37:46+01:00
[INFO] Final Memory: 25M/334M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:2.0:shade (default) on project launcher: Execution default of goal org.apache.maven.plugins:maven-shade-plugin:2.0:shade failed: A required class was missing while executing org.apache.maven.plugins:maven-shade-plugin:2.0:shade: org/sonatype/aether/graph/Dependency
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-shade-plugin:2.0
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/vorburger/.m2/repository/org/apache/maven/plugins/maven-shade-plugin/2.0/maven-shade-plugin-2.0.jar
[ERROR] urls[1] = file:/home/vorburger/.m2/repository/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar
[ERROR] urls[2] = file:/home/vorburger/.m2/repository/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar
[ERROR] urls[3] = file:/home/vorburger/.m2/repository/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar
[ERROR] urls[4] = file:/home/vorburger/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar
[ERROR] urls[5] = file:/home/vorburger/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
[ERROR] urls[6] = file:/home/vorburger/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[7] = file:/home/vorburger/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[8] = file:/home/vorburger/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar
[ERROR] urls[9] = file:/home/vorburger/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.1/plexus-utils-3.0.1.jar
[ERROR] urls[10] = file:/home/vorburger/.m2/repository/asm/asm/3.3.1/asm-3.3.1.jar
[ERROR] urls[11] = file:/home/vorburger/.m2/repository/asm/asm-commons/3.3.1/asm-commons-3.3.1.jar
[ERROR] urls[12] = file:/home/vorburger/.m2/repository/asm/asm-tree/3.3.1/asm-tree-3.3.1.jar
[ERROR] urls[13] = file:/home/vorburger/.m2/repository/org/jdom/jdom/1.1/jdom-1.1.jar
[ERROR] urls[14] = file:/home/vorburger/.m2/repository/org/apache/maven/shared/maven-dependency-tree/2.0/maven-dependency-tree-2.0.jar
[ERROR] urls[15] = file:/home/vorburger/.m2/repository/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.jar
[ERROR] urls[16] = file:/home/vorburger/.m2/repository/org/vafer/jdependency/0.7/jdependency-0.7.jar
[ERROR] urls[17] = file:/home/vorburger/.m2/repository/commons-io/commons-io/1.3.2/commons-io-1.3.2.jar
[ERROR] urls[18] = file:/home/vorburger/.m2/repository/asm/asm-analysis/3.2/asm-analysis-3.2.jar
[ERROR] urls[19] = file:/home/vorburger/.m2/repository/asm/asm-util/3.2/asm-util-3.2.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------: org.sonatype.aether.graph.Dependency
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound
```
